### PR TITLE
sparse: oneshot service to disable audio fluence on speaker

### DIFF
--- a/sparse/lib/systemd/system/fluence-speaker-false.service
+++ b/sparse/lib/systemd/system/fluence-speaker-false.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Disable audio fluence for speaker
+DefaultDependencies=false
+
+[Service]
+Type=oneshot
+ExecStart=/bin/sh /usr/bin/droid/fluence-speaker-false.sh
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/sparse/lib/systemd/system/multi-user.target.wants/fluence-speaker-false.service
+++ b/sparse/lib/systemd/system/multi-user.target.wants/fluence-speaker-false.service
@@ -1,0 +1,1 @@
+../fluence-speaker-false.service

--- a/sparse/usr/bin/droid/fluence-speaker-false.sh
+++ b/sparse/usr/bin/droid/fluence-speaker-false.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+echo -n false > /data/property/persist.audio.fluence.speaker
+chmod 600 /data/property/persist.audio.fluence.speaker
+


### PR DESCRIPTION
This seems to be the only way to override persist, -property set in build.prop.
Adding property to default.prop did not help. (ro. -properties work though)
File in sparse/data/property/ does not go there.