### PR TITLE
[bluetooh] fix bluetooth mac address

### DIFF
--- a/sparse/lib/systemd/system/droid-hcismd-up.service
+++ b/sparse/lib/systemd/system/droid-hcismd-up.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Enable Bluetooth HCI over SMD
 DefaultDependencies=false
-After=local-fs.target
+After=jolla-rfkill-hciwait.service
 
 [Service]
 Type=oneshot

--- a/sparse/usr/bin/droid/droid-hcismd-up.sh
+++ b/sparse/usr/bin/droid/droid-hcismd-up.sh
@@ -1,14 +1,18 @@
 #!/bin/sh
 
+echo Starting | systemd-cat -p info -t "droid-hcismd-up.sh"
+
 # transport is smd
 setprop ro.qualcomm.bt.hci_transport smd
 
-# initialise chip and board-address with correct mac
-BLUETOOTH_MAC=`/system/bin/btnvtool -p 2>&1| sed -n 's/ //g;s/.*://;s/\./\:/g;y/abcdef/ABCDEF/;1p'`
-echo Setting bluetooth address to $BLUETOOTH_MAC | systemd-cat -p info -t "droid-hcismd-up.sh"
+# initialise chip
+init_output=$(/system/bin/hci_qcomm_init -e -d /dev/ttyHS0 2>1)
+echo $init_output | systemd-cat -p info -t "droid-hcismd-up.sh"
 
-echo $BLUETOOTH_MAC > /var/lib/bluetooth/board-address
-/system/bin/hci_qcomm_init -d /dev/ttysmd3 -s 3000000 -i 115200 -r 32000000 -p 0 -P 1 -b $BLUETOOTH_MAC
+bt_mac=$(echo $init_output | grep -oP '([0-9a-f]{2}:){5}([0-9a-f]{2})')
+
+echo Setting bluetooth address to $bt_mac | systemd-cat -p info -t "droid-hcismd-up.sh"
+echo $bt_mac > /var/lib/bluetooth/board-address
 
 # Maximum number of attempts to enable hcismd to try to get
 # hci0 to come online.  Writing to sysfs too early seems to
@@ -19,11 +23,13 @@ seq 1 $MAXTRIES | while read i ; do
     echo 1 > /sys/module/hci_smd/parameters/hcismd_set
     if [ -e /sys/class/bluetooth/hci0 ] ; then
         # found hci0, exit successfully
+        echo Init succesfully | systemd-cat -p info -t "droid-hcismd-up.sh"
         exit 0
     fi
     sleep 1
     if [ $i == $MAXTRIES ] ; then
         # must have gotten through all our retries, fail
+        echo Init failed | systemd-cat -p info -t "droid-hcismd-up.sh"
         exit 1
     fi
 done


### PR DESCRIPTION
postpone start to after jolla-rfkill, to allow setprop to work
use correct device for qcom_init, and get BT mac address from its output
add some more journal loggings