### PR TITLE
[bluetooth] do not set empty bt mac, initialize a bit later

### DIFF
--- a/sparse/lib/systemd/system/droid-hcismd-up.service
+++ b/sparse/lib/systemd/system/droid-hcismd-up.service
@@ -1,7 +1,8 @@
 [Unit]
 Description=Enable Bluetooth HCI over SMD
-DefaultDependencies=false
-After=jolla-rfkill-hciwait.service
+After=droid-late-start.target
+Before=bluetooth.service
+Conflicts=shutdown.target actdead.target
 
 [Service]
 Type=oneshot

--- a/sparse/usr/bin/droid/bluetooth-rfkill.sh
+++ b/sparse/usr/bin/droid/bluetooth-rfkill.sh
@@ -9,6 +9,9 @@ else
       echo "lescan already done" | systemd-cat -p info -t "bluetooth-rfkill.sh"
       exit 0
     fi
+    if [ "`getprop droid.bt.scanned`" != "false" ]; then
+      sleep 5
+    fi
     echo "performing initial lescan" | systemd-cat -p info -t "bluetooth-rfkill.sh"
     hcitool lescan &
     pid=$!

--- a/sparse/usr/bin/droid/droid-hcismd-up.sh
+++ b/sparse/usr/bin/droid/droid-hcismd-up.sh
@@ -11,6 +11,11 @@ echo $init_output | systemd-cat -p info -t "droid-hcismd-up.sh"
 
 bt_mac=$(echo $init_output | grep -oP '([0-9a-f]{2}:){5}([0-9a-f]{2})')
 
+if [ -z "$bt_mac" ] ; then
+  echo Setting bluetooth address failed - not setting empty address | systemd-cat -p info -t "droid-hcismd-up.sh"
+  exit 1
+fi
+
 echo Setting bluetooth address to $bt_mac | systemd-cat -p info -t "droid-hcismd-up.sh"
 echo $bt_mac > /var/lib/bluetooth/board-address
 


### PR DESCRIPTION
If mac address is not acquired with hci_qcomm_init, let systemd to restart
there is no more jolla-rfkill-hciwait, so start after droid-late-start
initial lescan needs to be delayed, otherwise UI shows it is scanning if bluetooth was on when rebooting