### PR TITLE
[wlan] rename loader service

### DIFF
--- a/sparse/lib/systemd/system/multi-user.target.wants/wifi-module-load.service
+++ b/sparse/lib/systemd/system/multi-user.target.wants/wifi-module-load.service
@@ -1,1 +1,0 @@
-../wifi-module-load.service

--- a/sparse/lib/systemd/system/multi-user.target.wants/wlan-module-load.service
+++ b/sparse/lib/systemd/system/multi-user.target.wants/wlan-module-load.service
@@ -1,0 +1,1 @@
+../wlan-module-load.service

--- a/sparse/lib/systemd/system/wlan-module-load.service
+++ b/sparse/lib/systemd/system/wlan-module-load.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Load wifi module
+Description=Load wlan module
 Conflicts=shutdown.target actdead.target
 
 [Service]


### PR DESCRIPTION
dsme reset_wlan_module assumes service name is wlan-module-load.service, so rename our loader service accordingly.
ref: https://git.merproject.org/mer-core/dsme/commit/c377c349079b470db38ba6394121b6d899004963