### PR TITLE
Add quirks=-input_atoi to restore video volume

### DIFF
--- a/sparse/etc/pulse/arm_msm8974_opx-onyx.pa
+++ b/sparse/etc/pulse/arm_msm8974_opx-onyx.pa
@@ -38,7 +38,7 @@ load-module module-augment-properties
 
 load-module module-null-sink sink_name=sink.null rate=48000
 
-load-module module-droid-card rate=48000 mute_routing_before=24576 mute_routing_after=4096
+load-module module-droid-card rate=48000 mute_routing_before=24576 mute_routing_after=4096 quirks=-input_atoi
 
 ### Audioflingerglue
 load-module module-droid-glue


### PR DESCRIPTION
Adding the quirk restores video recording volume in onyx, fixes https://github.com/kimmoli/sfos-onyx-issues/issues/48

Tested on onyx with this patch and the video was recorded with loud voice.